### PR TITLE
Change visual forecasting to forecasting to conform to the paper

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,7 +271,7 @@
                 />
               </div>
               <div class="card-info">
-                <h3 class="card-title">Visual Forecasting</h3>
+                <h3 class="card-title">Forecasting</h3>
               </div>
             </div>
           </div>
@@ -325,7 +325,7 @@
               </li>
 
               <li id="forecasting" class="nav-link">
-                <a data-toggle="tab" href="#menu2">Visual Forecasting</a>
+                <a data-toggle="tab" href="#menu2">Forecasting</a>
               </li>
               <li id="hoi" class="nav-link active">
                 <a data-toggle="tab" href="#menu3">HOI</a>
@@ -414,7 +414,7 @@
                       />
                     </div>
                     <div class="tab-card-content">
-                      <h5 class="card-title">Visual Forecasting</h5>
+                      <h5 class="card-title">Forecasting</h5>
                       <p class="card-text">
                         <em>What will I do next?</em><br />
                         Predicting the future is a critical skill for AI systems to


### PR DESCRIPTION
We noted that the last draft of the paper reports "Forecasting" rather than "Visual Forecasting", so we changed accordingly. I am asking to pull this directly on main because the dev branch is at the moment out of sync (it does not contain our last edits, so I cannot commit changes incrementally). The changes are very small, I hope that's not a problem.