### PR TITLE
Meta - Fix broken docs link and add ego4d team member

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
                   rel="noopener noreferrer"
                 >
                   Watch Video &nearr;
-                </a> 
+                </a>
                  <a
                   class="btn btn-primary btn-translucent"
                   role="button"
@@ -226,7 +226,7 @@
             <ul id="nav-menu-list" data-app-modern-menu="true">
               <li class="nav-item">
                 <a href="https://ego4d-data.org/docs/start-here/" class="nav-link" target="_blank">Start Here</a>
-              </li>    
+              </li>
               <li class="nav-item">
                 <a href="#benchmarks" class="nav-link">Benchmarks</a>
               </li>
@@ -1008,7 +1008,7 @@
                       >BibTex (.bib)</a
                     ></b
                   >
-                    <b>(ArXiv will be updated before end of Feb)</b> 
+                    <b>(ArXiv will be updated before end of Feb)</b>
                 </p>
                 <a href="https://arxiv.org/abs/2110.07058" target="_blank">
                 <img src="./assets/images/paperOverview.png" width="100%" /></a>
@@ -1074,7 +1074,7 @@ You can review a draft of the licenses before signing <a href="./pdfs/Ego4D-Lice
                   partner/university, date of recording, recording equipment, as
                   well as video parts when the video is made up of smaller
                   chunks. Information about the availability of IMU, Audio and
-                  whether videos have been redacted are also included. <a href="https://ego4d-data.org/docs/data-overview/" target="_blank">An overview of metadata and annotations can be found here</a>.
+                  whether videos have been redacted are also included. Overviews of the <a href="https://ego4d-data.org/docs/data/metadata/" target="_blank">metadata</a> and <a href="https://ego4d-data.org/docs/data/annotations/">annotations</a> can be found in <a href="https://ego4d-data.org/docs/">our docs</a>.
                 </p>
               </div>
             </div>
@@ -1166,7 +1166,7 @@ You can review a draft of the licenses before signing <a href="./pdfs/Ego4D-Lice
                 </h4>
                 <p>
                  A sample visualisation of our scenarios is below. Outer circle shows the 14 most common scenarios (70% of the data). Wordle shows scenarios in the remaining 30%. Inner circle is color coded by the contributing partner (see map marker above).
-                 
+
                 </p>
                   <div class="image">
                   <img
@@ -1840,7 +1840,7 @@ You can review a draft of the licenses before signing <a href="./pdfs/Ego4D-Lice
                   rel="noopener noreferrer"
                   ><i class="fas fa-link"></i
                 ></a>
-              </li>              
+              </li>
               <li>Fiona Ryan
                 <a
                   href="https://fkryan.github.io/"
@@ -1856,7 +1856,7 @@ You can review a draft of the licenses before signing <a href="./pdfs/Ego4D-Lice
                   rel="noopener noreferrer"
                   ><i class="fab fa-linkedin"></i
                 ></a>
-              </li>    
+              </li>
               <li>Wenqi Jia
                 <a
                   href="https://www.linkedin.com/in/wenqijia/"
@@ -1864,7 +1864,7 @@ You can review a draft of the licenses before signing <a href="./pdfs/Ego4D-Lice
                   rel="noopener noreferrer"
                   ><i class="fab fa-linkedin"></i
                 ></a>
-              </li>           
+              </li>
             </ul>
             <h4 class="card-title">
               Universidad de los Andes, Colombia

--- a/index.html
+++ b/index.html
@@ -1669,6 +1669,14 @@ You can review a draft of the licenses before signing <a href="./pdfs/Ego4D-Lice
               <li>Hanbyul Joo</li>
               <li>Jachym Kolar</li>
               <li>Satwik Kottur</li>
+              <li>Devansh Kukreja
+                <a
+                  href="https://www.linkedin.com/in/devanshkukreja/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  ><i class="fab fa-linkedin"></i
+                ></a>
+              </li>
               <li>Anurag Kumar, FRL</li>
               <li>Federico Landini</li>
               <li>Chao Li, FRL</li>


### PR DESCRIPTION
Fixes broken links from this [this Github Issue](https://github.com/facebookresearch/Ego4d/issues/66) and adds a missing Ego4D team member (myself) to the team list.

The Metadata Block was changed from this with a broken link:
![Screen Shot 2022-03-02 at 11 34 20 AM](https://user-images.githubusercontent.com/1356687/156405711-c3f88d22-acf6-4a99-b531-fd9441cff5fe.png)

to this with three valid links:
![Screen Shot 2022-03-02 at 11 31 20 AM](https://user-images.githubusercontent.com/1356687/156405452-9184752c-5d2a-4249-a15b-f1f9314d6c3d.png)